### PR TITLE
Pack the last rect

### DIFF
--- a/src/Packer.cpp
+++ b/src/Packer.cpp
@@ -226,7 +226,7 @@ void mpbp::Packer::Pack(const std::span<mpbp::Rect> rects)
     this->placeNewPage(*rect);
     next_rect();
   }
-  for (; rect_i < rects.size(); next_rect())
+  for (; rect_i <= rects.size(); next_rect())
   {
     if (this->tryPlaceSpace(*rect)) continue;
     if (this->tryPlaceExpandBin(*rect)) continue;


### PR DESCRIPTION
Fix the loop that doesn't pack the last rect in the rect span passed into the packer.