### PR TITLE
Patch 1.0.2 bugfixes

### DIFF
--- a/src/Packer.cpp
+++ b/src/Packer.cpp
@@ -172,13 +172,13 @@ void mpbp::Packer::spaceLeftoverPage()
 {
   if (this->top_bin_width < this->max_width)
   {
-    this->spaces.emplace_back(this->top_bin_width, 0, this->max_width - this->top_bin_width,
-                              this->top_bin_height, this->getTopPageI());
+    this->spaces.emplace_back(this->top_bin_width, 0, this->getTopPageI(), this->max_width - this->top_bin_width,
+                              this->top_bin_height);
   }
   if (this->top_bin_height < this->max_height)
   {
-    this->spaces.emplace_back(0, this->top_bin_height, this->max_width,
-                              this->max_height - this->top_bin_height, this->getTopPageI());
+    this->spaces.emplace_back(0, this->top_bin_height, this->getTopPageI(), this->max_width,
+                              this->max_height - this->top_bin_height);
   }
 }
 
@@ -190,6 +190,11 @@ void mpbp::Packer::placeNewPage(mpbp::Rect& rect)
   {
     this->width = rect.GetWidth();
     this->height = rect.GetHeight();
+  }
+  else
+  {
+    this->width = this->max_width;
+    this->height = this->max_height;
   }
   this->top_bin_width = rect.GetWidth();
   this->top_bin_height = rect.GetHeight();

--- a/test/src/packer_test.cpp
+++ b/test/src/packer_test.cpp
@@ -46,7 +46,7 @@ bool noInvalidSpace(std::vector<mpbp::Space> spaces)
 {
   for (const auto& space : spaces)
   {
-    if (space.GetLeftX() < 0 || space.GetTopY() < 0 || space.GetPage() < 0 || space.GetWidth() <= 0 || space.GetHeight() <= 0)
+    if (space.GetIsDegenerate())
     {
       return false;
     }

--- a/test/src/packer_test.cpp
+++ b/test/src/packer_test.cpp
@@ -5,6 +5,7 @@
 #include <catch2/catch_all.hpp>
 #include <mpbp/Packer.hpp>
 #include <mpbp/Rect.hpp>
+#include <mpbp/Space.hpp>
 #include <vector>
 #include <cstddef>
 
@@ -24,6 +25,30 @@ bool noRectIntersect(std::vector<mpbp::Rect>& rects)
           return false;
         }
       }
+    }
+  }
+  return true;
+}
+
+bool noUnplacedRect(std::vector<mpbp::Rect>& rects)
+{
+  for(const auto& rect : rects)
+  {
+    if (rect.GetLeftX() < 0 || rect.GetRightX() < 0 || rect.GetPage() < 0)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool noInvalidSpace(std::vector<mpbp::Space> spaces)
+{
+  for (const auto& space : spaces)
+  {
+    if (space.GetLeftX() < 0 || space.GetTopY() < 0 || space.GetPage() < 0 || space.GetWidth() <= 0 || space.GetHeight() <= 0)
+    {
+      return false;
     }
   }
   return true;
@@ -54,6 +79,8 @@ SCENARIO("Packer is used to bin pack")
         packer.Pack(rects);
 
         THEN("No Rect intersect") { CHECK(noRectIntersect(rects)); }
+        THEN("All rects are placed") { CHECK(noUnplacedRect(rects)); }
+        THEN("No spaces are invalid") { CHECK(noInvalidSpace(packer.GetSpaces())); }
       }
 
       WHEN("The vector of Rect is cut in half and packed online")
@@ -65,6 +92,8 @@ SCENARIO("Packer is used to bin pack")
         packer.Pack(spanb);
 
         THEN("No Rect intersect") { CHECK(noRectIntersect(rects)); }
+        THEN("All rects are placed") { CHECK(noUnplacedRect(rects)); }
+        THEN("No spaces are invalid") { CHECK(noInvalidSpace(packer.GetSpaces())); }
       }
     }
 


### PR DESCRIPTION
This is the final bunch of fixes for patch 1.0.2. Tests have been added to help find remaining bugs and ensure they don't creep up again in the future. An issue where Spaces were added to the Space vector of the Packer that were constructed with invalid arguments was fixed. An issue that caused the final rect of the rect span of a pack to not be packed was fixed. 