### PR TITLE
Patch 1.0.2

### DIFF
--- a/CHANGE_NOTES.md
+++ b/CHANGE_NOTES.md
@@ -4,10 +4,19 @@ SPDX-FileCopyrightText: 2022 Daniel Valcour <fosssweeper@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 
+# 1.0.2
+
+## Bugfixes:
+* Fixed degenerate Spaces sometimes being added to the Packer's space vector due to invalid constructor argument order.
+* Fixed the last Rect of a pack being ignored.
+
+## Tooling:
+* Added new automatic tests to detect similar bugs to those patched in both this and the previous patch.
+
 # 1.0.1
 
 ## Bugfixes:
-* Fixed issue with spaces being added to the Packer's space vector with a width or height of 0.
+* Fixed issue with Spaces being added to the Packer's space vector with a width or height of 0.
 
 # 1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.19)
 
 PROJECT(mpbp
-    VERSION 1.0.1
+    VERSION 1.0.2
     DESCRIPTION "A multi-page bin packing library."
     LANGUAGES CXX
 )

--- a/src/Packer.cpp
+++ b/src/Packer.cpp
@@ -172,13 +172,13 @@ void mpbp::Packer::spaceLeftoverPage()
 {
   if (this->top_bin_width < this->max_width)
   {
-    this->spaces.emplace_back(this->top_bin_width, 0, this->max_width - this->top_bin_width,
-                              this->top_bin_height, this->getTopPageI());
+    this->spaces.emplace_back(this->top_bin_width, 0, this->getTopPageI(), this->max_width - this->top_bin_width,
+                              this->top_bin_height);
   }
   if (this->top_bin_height < this->max_height)
   {
-    this->spaces.emplace_back(0, this->top_bin_height, this->max_width,
-                              this->max_height - this->top_bin_height, this->getTopPageI());
+    this->spaces.emplace_back(0, this->top_bin_height, this->getTopPageI(), this->max_width,
+                              this->max_height - this->top_bin_height);
   }
 }
 
@@ -190,6 +190,11 @@ void mpbp::Packer::placeNewPage(mpbp::Rect& rect)
   {
     this->width = rect.GetWidth();
     this->height = rect.GetHeight();
+  }
+  else
+  {
+    this->width = this->max_width;
+    this->height = this->max_height;
   }
   this->top_bin_width = rect.GetWidth();
   this->top_bin_height = rect.GetHeight();

--- a/src/Packer.cpp
+++ b/src/Packer.cpp
@@ -226,7 +226,7 @@ void mpbp::Packer::Pack(const std::span<mpbp::Rect> rects)
     this->placeNewPage(*rect);
     next_rect();
   }
-  for (; rect_i < rects.size(); next_rect())
+  for (; rect_i <= rects.size(); next_rect())
   {
     if (this->tryPlaceSpace(*rect)) continue;
     if (this->tryPlaceExpandBin(*rect)) continue;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,8 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.19)
-find_package(Catch2 CONFIG REQUIRED)
-
+Include(FetchContent)
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG        v3.1.0
+)
+FetchContent_MakeAvailable(Catch2)
 set(MPBP_TEST_SOURCES
     "space_test.cpp"
     "rect_test.cpp"

--- a/test/src/packer_test.cpp
+++ b/test/src/packer_test.cpp
@@ -5,6 +5,7 @@
 #include <catch2/catch_all.hpp>
 #include <mpbp/Packer.hpp>
 #include <mpbp/Rect.hpp>
+#include <mpbp/Space.hpp>
 #include <vector>
 #include <cstddef>
 
@@ -24,6 +25,30 @@ bool noRectIntersect(std::vector<mpbp::Rect>& rects)
           return false;
         }
       }
+    }
+  }
+  return true;
+}
+
+bool noUnplacedRect(std::vector<mpbp::Rect>& rects)
+{
+  for(const auto& rect : rects)
+  {
+    if (rect.GetLeftX() < 0 || rect.GetRightX() < 0 || rect.GetPage() < 0)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool noInvalidSpace(std::vector<mpbp::Space> spaces)
+{
+  for (const auto& space : spaces)
+  {
+    if (space.GetIsDegenerate())
+    {
+      return false;
     }
   }
   return true;
@@ -54,6 +79,8 @@ SCENARIO("Packer is used to bin pack")
         packer.Pack(rects);
 
         THEN("No Rect intersect") { CHECK(noRectIntersect(rects)); }
+        THEN("All rects are placed") { CHECK(noUnplacedRect(rects)); }
+        THEN("No spaces are invalid") { CHECK(noInvalidSpace(packer.GetSpaces())); }
       }
 
       WHEN("The vector of Rect is cut in half and packed online")
@@ -65,6 +92,8 @@ SCENARIO("Packer is used to bin pack")
         packer.Pack(spanb);
 
         THEN("No Rect intersect") { CHECK(noRectIntersect(rects)); }
+        THEN("All rects are placed") { CHECK(noUnplacedRect(rects)); }
+        THEN("No spaces are invalid") { CHECK(noInvalidSpace(packer.GetSpaces())); }
       }
     }
 


### PR DESCRIPTION
# 1.0.2

## Bugfixes:
* Fixed degenerate Spaces sometimes being added to the Packer's space vector due to invalid constructor argument order.
* Fixed the last Rect of a pack being ignored.

## Tooling:
* Added new automatic tests to detect similar bugs to those patched in both this and the previous patch.